### PR TITLE
Externalize environment.properties

### DIFF
--- a/geoserver/latest/templates/env-properties-secret.yaml
+++ b/geoserver/latest/templates/env-properties-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "geoserver.fullname" . }}-env-properties
+data:
+  environment.properties: |-
+              {{ .Values.geoserver.env_properties | b64enc }}
+

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "geoserver.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        checksum/geoserver-env-properties-secret: {{ include (print $.Template.BasePath "/env-properties-secret.yaml") . | sha256sum }}
       labels:
         {{- include "geoserver.selectorLabels" . | nindent 8 }}
     spec:
@@ -68,6 +69,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: ENV_PROPERTIES
+              value: /usr/local/tomcat/conf/environment.properties
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -194,6 +197,10 @@ spec:
               mountPath: /usr/local/tomcat/conf/context.xml
               subPath: context.xml
               readOnly: true
+            - name: env-properties
+              mountPath: /usr/local/tomcat/conf/environment.properties
+              subPath: environment.properties
+              readOnly: true
             - name: server-xml
               mountPath: /usr/local/tomcat/conf/server.xml
               subPath: server.xml
@@ -276,6 +283,9 @@ spec:
       - name: context
         secret:
           secretName: {{ include "geoserver.fullname" .}}-context
+      - name: env-properties
+        secret:
+          secretName: {{ include "geoserver.fullname" .}}-env-properties
       - name: server-xml
         configMap:
           name: geoserver

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -151,3 +151,9 @@ geoserver:
   geoserver_cors_allowed_origins: "*"
   geoserver_cors_allowed_headers: "*"
   geoserver_cors_allow_credentials: "false"
+
+  env_properties: |
+    EXAMPLE_DB_NAME=geoserver
+    EXAMPLE_DB_HOST=localhost
+    EXAMPLE_DB_USER=geoserver
+    EXAMPLE_DB_PASS=geoserver


### PR DESCRIPTION
The Value `geoserver.env_properties` is used as content for a dedicated secret.
The secret is mounted at `/usr/local/tomcat/conf/environment.properties`.
The path of the file is specified with the env var `ENV_PROPERTIES`.