### PR TITLE
Persist the GeoServer data (uploads) directory

### DIFF
--- a/geoserver/latest/templates/persistence.yaml
+++ b/geoserver/latest/templates/persistence.yaml
@@ -16,6 +16,24 @@ spec:
   {{- end }}
 {{- end }}
 ---
+{{- if and .Values.persistence.data (not .Values.persistence.data.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "geoserver.fullname" . }}-data
+  labels:
+    {{- include "geoserver.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size | quote }}
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass }}
+  {{- end }}
+{{- end }}
+---
 {{- if and .Values.persistence.memdumps (not .Values.persistence.memdumps.existingClaim) }}
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -207,6 +207,8 @@ spec:
               readOnly: true
             - name: gs-datadir
               mountPath: /var/geoserver/datadir
+            - name: gs-data
+              mountPath: /var/geoserver/data
             - name: gs-memdumps
               mountPath: /var/geoserver/memory_dumps
             - name: gs-audits
@@ -259,6 +261,11 @@ spec:
       - name: gs-datadir
         persistentVolumeClaim:
           claimName: {{ include "geoserver.fullname" . }}-datadir
+      {{- end }}
+      {{- if .Values.persistence.data }}
+      - name: gs-data
+        persistentVolumeClaim:
+          claimName: {{ include "geoserver.fullname" . }}-data
       {{- end }}
       {{- if .Values.persistence.memdumps }}
       - name: gs-memdumps

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -105,6 +105,10 @@ persistence:
     accessModes: ReadWriteOnce
     size: 1Gi
     storageClass: ""
+  data:
+    accessModes: ReadWriteOnce
+    size: 1Gi
+    storageClass: ""
   memdumps:
     accessModes: ReadWriteOnce
     size: 1Gi


### PR DESCRIPTION
Previously there was no persisted directory dedicated to uploaded resources outside of the data_dir.
Now such directory is mounted at /var/geoserver/data.

---

Test: files stored in the PV are accessible from GeoServer.
![image](https://github.com/user-attachments/assets/c8b7b4c2-fb15-46e9-976a-da961bb4ea71)
