### PR TITLE
fix: update default values of CORS allowed headers 

### DIFF
--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -157,7 +157,6 @@ geoserver:
   geoserver_cors_enabled: "false"
   geoserver_cors_allowed_methods: "GET,POST,PUT,HEAD,OPTIONS"
   geoserver_cors_allowed_origins: "*"
-  # geoserver_cors_allowed_headers: "*"
   geoserver_cors_allowed_headers: "accept,accept-language,cache-control,content-type,origin,pragma,priority,referer,user-agent,sec-fetch-dest,sec-fetch-mode,sec-fetch-site,authorization,x-requested-with,access-control-request-headers,access-control-request-method"
   geoserver_cors_allow_credentials: "false"
 


### PR DESCRIPTION
This PR update default values of CORS allowed headers  – refining the allowed request headers for improved control and compatibility.  

## Changes Introduced

- ✅ Explicitly restricts CORS headers to only known and required values instead of using the wildcard (`*`).  

- ✅ Improves security by ensuring that only intended headers are allowed in cross-origin requests.  