### PR TITLE
fix: improve helm chart testing and enforce version bumping

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -43,7 +43,13 @@ jobs:
 
     - name: Check changed charts
       run: |
-        ct lint --chart-dirs . --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
+        ct_output=$(ct lint --chart-dirs geoserver/latest,mapstore/latest --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false 2>&1)
+        if echo "$ct_output" | grep -q "No chart changes detected"; then
+          echo "[WARNING] No chart changes detected. Please bump the chart version if you made changes to the charts."
+          exit 1
+        else
+          echo "$ct_output"
+        fi
 
     - name: GeoServer - Unit Tests
       run: |


### PR DESCRIPTION
This PR updates the Helm CI workflow configuration to properly detect and lint nested chart directories - fixing chart validation that was previously skipped due to directory structure issues and enforcing chart version bumping.

## Changes Introduced

• ✅ Explicitly specifies chart directories (`geoserver/latest,mapstore/latest`) instead of using root directory discovery.

• ✅ Ensures chart-testing properly validates all Helm charts in the CI pipeline instead of skipping them.

• ✅ Enforces chart version bumping by failing the workflow when no chart changes are detected, preventing unchanged versions from being merged.