### PR TITLE
fix: add redirection in geoserver chart

### DIFF
--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -51,7 +51,11 @@ service:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location = / {
+        return 302 /geoserver;
+      }
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   finalizers: []


### PR DESCRIPTION
This PR adds a redirection in GeoServer chart when accessing `/` path

**Changed Introduce**
- `values.yaml`: Added an annotation to redirect traffic when accessing `/` path