### PR TITLE
fix(geoserver): use gwccache volume for GeoServer cache by default

### DIFF
--- a/geoserver/latest/Chart.yaml
+++ b/geoserver/latest/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/geoserver/latest/README.md
+++ b/geoserver/latest/README.md
@@ -169,7 +169,8 @@ geoserver:
   geoserver_audit_path: "/var/geoserver/audits"
   geoserver_heap_dump_dir: "/var/geoserver/memory_dumps"
   geoserver_data_dir: "/var/geoserver/datadir"
-  geoserver_cache_data_dir: "$(GEOSERVER_DATA_DIR)/gwc_cache_dir"
+  # Empty value uses a chart default based on persistence.gwccache.
+  geoserver_cache_data_dir: ""
   geoserver_cache_config_dir: "$(GEOSERVER_DATA_DIR)/gwc"
   geoserver_netcdf_data_dir: "/var/geoserver/netcdf_data_dir"
   geoserver_grib_cache_dir: "/var/geoserver/grib_cache_dir"

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -152,7 +152,7 @@ spec:
             - name: GEOSERVER_HEAP_DUMP_DIR
               value: "{{ .Values.geoserver.geoserver_heap_dump_dir }}"
             {{- end }}
-            {{- if $geowebcacheCacheDir }}
+            {{- if .Values.geoserver.geoserver_data_dir }}
             - name: GEOSERVER_DATA_DIR
               value: "{{ .Values.geoserver.geoserver_data_dir }}"
             {{- end }}

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -1,3 +1,7 @@
+{{- $geowebcacheCacheDir := .Values.geoserver.geoserver_cache_data_dir | default "$(GEOSERVER_DATA_DIR)/gwc_cache_dir" -}}
+{{- if and (not .Values.geoserver.geoserver_cache_data_dir) .Values.persistence.gwccache -}}
+{{- $geowebcacheCacheDir = "/var/geoserver/gwc_cache_dir" -}}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -148,7 +152,7 @@ spec:
             - name: GEOSERVER_HEAP_DUMP_DIR
               value: "{{ .Values.geoserver.geoserver_heap_dump_dir }}"
             {{- end }}
-            {{- if .Values.geoserver.geoserver_cache_data_dir }}
+            {{- if $geowebcacheCacheDir }}
             - name: GEOSERVER_DATA_DIR
               value: "{{ .Values.geoserver.geoserver_data_dir }}"
             {{- end }}
@@ -156,9 +160,9 @@ spec:
             - name: GEOWEBCACHE_CONFIG_DIR
               value: "{{ .Values.geoserver.geoserver_cache_config_dir }}"
             {{- end }}
-            {{- if .Values.geoserver.geoserver_cache_data_dir }}
+            {{- if $geowebcacheCacheDir }}
             - name: GEOWEBCACHE_CACHE_DIR
-              value: "{{ .Values.geoserver.geoserver_cache_data_dir }}"
+              value: "{{ $geowebcacheCacheDir }}"
             {{- end }}
             {{- if .Values.geoserver.geoserver_netcdf_data_dir }}
             - name: NETCDF_DATA_DIR

--- a/geoserver/latest/tests/statefulset_test.yaml
+++ b/geoserver/latest/tests/statefulset_test.yaml
@@ -31,3 +31,60 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
           value: geoserver
+
+  - it: should keep cache data dir under geoserver data dir by default
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEOWEBCACHE_CACHE_DIR
+            value: $(GEOSERVER_DATA_DIR)/gwc_cache_dir
+
+  - it: should point cache data dir to dedicated gwccache volume by default
+    template: statefulset.yaml
+    set:
+      persistence.gwccache.accessModes: ReadWriteOnce
+      persistence.gwccache.size: 1Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEOWEBCACHE_CACHE_DIR
+            value: /var/geoserver/gwc_cache_dir
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: gs-gwccache
+            mountPath: /var/geoserver/gwc_cache_dir
+
+  - it: should allow overriding cache data dir when gwccache volume is enabled
+    template: statefulset.yaml
+    set:
+      persistence.gwccache.accessModes: ReadWriteOnce
+      persistence.gwccache.size: 1Gi
+      geoserver.geoserver_cache_data_dir: /custom/gwc-cache
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEOWEBCACHE_CACHE_DIR
+            value: /custom/gwc-cache
+
+  - it: should keep gwccache default independent from custom data dir
+    template: statefulset.yaml
+    set:
+      persistence.gwccache.accessModes: ReadWriteOnce
+      persistence.gwccache.size: 1Gi
+      geoserver.geoserver_data_dir: /custom/geoserver/datadir
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEOSERVER_DATA_DIR
+            value: /custom/geoserver/datadir
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GEOWEBCACHE_CACHE_DIR
+            value: /var/geoserver/gwc_cache_dir

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -111,8 +111,7 @@ persistence:
     size: 1Gi
     storageClass: ""
   # Optional GWC cache directory
-  # Uncomment to enable. Mounted at `/var/geoserver/gwc_cache_dir`; remember
-  # to update the `geoserver_cache_data_dir` path.
+  # Uncomment to enable. Mounted at `/var/geoserver/gwc_cache_dir`.
   # gwccache:
   #   accessModes: ReadWriteOnce
   #   size: 1Gi
@@ -168,7 +167,8 @@ geoserver:
   geoserver_audit_path: "/var/geoserver/audits"
   geoserver_heap_dump_dir: "/var/geoserver/memory_dumps"
   geoserver_data_dir: "/var/geoserver/datadir"
-  geoserver_cache_data_dir: "$(GEOSERVER_DATA_DIR)/gwc_cache_dir"
+  # Empty value uses a chart default based on persistence.gwccache.
+  geoserver_cache_data_dir: ""
   geoserver_cache_config_dir: "$(GEOSERVER_DATA_DIR)/gwc"
   geoserver_netcdf_data_dir: "/var/geoserver/netcdf_data_dir"
   geoserver_grib_cache_dir: "/var/geoserver/grib_cache_dir"


### PR DESCRIPTION
This PR updates the GeoServer chart so that when the optional `gwccache` volume is enabled, `GEOWEBCACHE_CACHE_DIR` defaults to the mounted cache path at `/var/geoserver/gwc_cache_dir`.

If `gwccache` is not enabled, the chart keeps the existing default of `$(GEOSERVER_DATA_DIR)/gwc_cache_dir`. Explicit `geoserver_cache_data_dir` values still take priority.