### PR TITLE
fix(geoserver): deduplicate JAVA_OPTS giving helm chart values precedence 

### DIFF
--- a/geoserver/latest/Chart.yaml
+++ b/geoserver/latest/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -188,7 +188,7 @@ spec:
             - name: JAVA_XMX
               value: "{{ .Values.geoserver.geoserver_java_mem_xmx }}"
             {{- end }}
-            - name: JAVA_OPTS
+            - name: CATALINA_OPTS
               value: "-Xms$(JAVA_XMS) -Xmx$(JAVA_XMX) -Djava.awt.headless=true -server -Dfile.encoding=UTF8 \
                 \ -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC
                 \ -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -96,6 +96,65 @@ spec:
               chmod +x /tmp/geoserver-rest-config.sh
               sed 's|/usr/local/bin/geoserver-rest-config.sh|/tmp/geoserver-rest-config.sh|g' /entrypoint.sh > /tmp/entrypoint.sh
               chmod +x /tmp/entrypoint.sh
+
+              # Merge HELM_CATALINA_OPTS and CATALINA_OPTS with key-based deduplication.
+              # Helm chart options take precedence over image-defined defaults.
+              # Note on key extraction logic:
+              # - Flags like -Xms4G / -Xmx4G have no '=' so ${opt%%=*} alone would evaluate to full value
+              #   (e.g., '-Xms4G'), allowing image defaults like '-Xms2G' to bypass deduplication.
+              # - Explicit pattern matching ensures -Xms, -Xmx, -Xss resolve to common keys.
+              # - Key-value flags (-Dfoo=bar, -XX:Opt=val) use ${opt%%=*} to strip values for matching.
+              combined_opts=""
+              seen_keys=""
+              helm_keys=""
+
+              # 1. Process Helm chart provided options first (highest precedence)
+              for opt in ${HELM_CATALINA_OPTS}; do
+                case "$opt" in
+                  -Xms*) key="-Xms" ;;
+                  -Xmx*) key="-Xmx" ;;
+                  -Xss*) key="-Xss" ;;
+                  -XX:*) key="${opt%%=*}" ;;
+                  -D*)   key="${opt%%=*}" ;;
+                  *=*)   key="${opt%%=*}" ;;
+                  *)     key="$opt" ;;
+                esac
+                case " $helm_keys " in
+                  *" $key "*) ;;
+                  *) helm_keys="$helm_keys $key" ;;
+                esac
+                case " $seen_keys " in
+                  *" $key "*) ;;
+                  *) seen_keys="$seen_keys $key"; combined_opts="$combined_opts $opt" ;;
+                esac
+              done
+
+              # 2. Process image-defined CATALINA_OPTS defaults, skipping keys overridden by Helm
+              for opt in ${CATALINA_OPTS}; do
+                case "$opt" in
+                  -Xms*) key="-Xms" ;;
+                  -Xmx*) key="-Xmx" ;;
+                  -Xss*) key="-Xss" ;;
+                  -XX:*) key="${opt%%=*}" ;;
+                  -D*)   key="${opt%%=*}" ;;
+                  *=*)   key="${opt%%=*}" ;;
+                  *)     key="$opt" ;;
+                esac
+                case " $seen_keys " in
+                  *" $key "*)
+                    # Log when a Helm chart configuration overrides an image default
+                    case " $helm_keys " in
+                      *" $key "*)
+                        echo "[INFO] Helm chart overridden CATALINA_OPTS value for '${key}': image provided '${opt}'"
+                        ;;
+                    esac
+                    ;;
+                  *) seen_keys="$seen_keys $key"; combined_opts="$combined_opts $opt" ;;
+                esac
+              done
+
+              # Export final deduplicated CATALINA_OPTS and run entrypoint
+              export CATALINA_OPTS="${combined_opts# }"
               exec /tmp/entrypoint.sh
           env:
             - name: APP_LOCATION
@@ -188,14 +247,14 @@ spec:
             - name: JAVA_XMX
               value: "{{ .Values.geoserver.geoserver_java_mem_xmx }}"
             {{- end }}
-            - name: CATALINA_OPTS
+            - name: HELM_CATALINA_OPTS
               value: "-Xms$(JAVA_XMS) -Xmx$(JAVA_XMX) -Djava.awt.headless=true -server -Dfile.encoding=UTF8 \
-                \ -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC
-                \ -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true
-                \ -Dorg.geotools.coverage.jaiext.enabled=\"$(JAI_EXT_ENABLED)\" -DGEOSERVER_LOG_LOCATION=\"$(GEOSERVER_LOG_LOCATION)\" -DGEOWEBCACHE_CONFIG_DIR=\"$(GEOWEBCACHE_CONFIG_DIR)\"
-                \ -DGEOWEBCACHE_CACHE_DIR=$(GEOWEBCACHE_CACHE_DIR) -DNETCDF_DATA_DIR=$(NETCDF_DATA_DIR) -DGRIB_CACHE_DIR=$(GRIB_CACHE_DIR) -DGEOSERVER_CSRF_DISABLED=\"$(GEOSERVER_CSRF_DISABLED)\"
-                \ -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$(GEOSERVER_HEAP_DUMP_DIR)/$(POD_HOSTNAME).hprof -DGEOSERVER_DATA_DIR=\"$(GEOSERVER_DATA_DIR)\"
-                \ -DGEOSERVER_AUDIT_PATH=\"$(GEOSERVER_AUDIT_PATH)\" -Dpod.hostname=\"$(POD_HOSTNAME)\"
+                \ -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC \
+                \ -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true \
+                \ -Dorg.geotools.coverage.jaiext.enabled=\"$(JAI_EXT_ENABLED)\" -DGEOSERVER_LOG_LOCATION=\"$(GEOSERVER_LOG_LOCATION)\" -DGEOWEBCACHE_CONFIG_DIR=\"$(GEOWEBCACHE_CONFIG_DIR)\" \
+                \ -DGEOWEBCACHE_CACHE_DIR=$(GEOWEBCACHE_CACHE_DIR) -DNETCDF_DATA_DIR=$(NETCDF_DATA_DIR) -DGRIB_CACHE_DIR=$(GRIB_CACHE_DIR) -DGEOSERVER_CSRF_DISABLED=\"$(GEOSERVER_CSRF_DISABLED)\" \
+                \ -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$(GEOSERVER_HEAP_DUMP_DIR)/$(POD_HOSTNAME).hprof -DGEOSERVER_DATA_DIR=\"$(GEOSERVER_DATA_DIR)\" \
+                \ -DGEOSERVER_AUDIT_PATH=\"$(GEOSERVER_AUDIT_PATH)\" -Dpod.hostname=\"$(POD_HOSTNAME)\" \
                 \ -DALLOW_ENV_PARAMETRIZATION=true -DPROXY_BASE_URL='$(PROXY_BASE_URL)' -DPROXY_BASE_URL_HEADERS='$(PROXY_BASE_URL_HEADERS)'"
             - name: EXTRA_GEOSERVER_OPTS
               value: "{{ .Values.geoserver.geoserver_extra_opts }}"

--- a/geoserver/latest/tests/statefulset_test.yaml
+++ b/geoserver/latest/tests/statefulset_test.yaml
@@ -120,27 +120,29 @@ tests:
               \ -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$(GEOSERVER_HEAP_DUMP_DIR)/$(POD_HOSTNAME).hprof -DGEOSERVER_DATA_DIR=\"$(GEOSERVER_DATA_DIR)\" \
               \ -DGEOSERVER_AUDIT_PATH=\"$(GEOSERVER_AUDIT_PATH)\" -Dpod.hostname=\"$(POD_HOSTNAME)\" \
               \ -DALLOW_ENV_PARAMETRIZATION=true -DPROXY_BASE_URL='$(PROXY_BASE_URL)' -DPROXY_BASE_URL_HEADERS='$(PROXY_BASE_URL_HEADERS)'"
+      # Verify HELM_CATALINA_OPTS loop runs before CATALINA_OPTS loop to enforce Helm option precedence
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'for opt in \$\{HELM_CATALINA_OPTS\}; do'
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: 'for opt in \$\{CATALINA_OPTS\}; do'
+          pattern: 'for opt in \$\{HELM_CATALINA_OPTS\}; do[\s\S]*helm_keys="\$helm_keys \$key"[\s\S]*for opt in \$\{CATALINA_OPTS\}; do'
+      # Verify explicit pattern matching for memory options (-Xms, -Xmx)
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '-Xms\*\) key="-Xms"'
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '-Xmx\*\) key="-Xmx"'
+      # Verify pattern stripping for key-value options (-XX:, -D)
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '-XX:\*\) key="\$\{opt%%=\*\}"'
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '-D\*\)   key="\$\{opt%%=\*\}"'
+      # Verify debug logging statement for overridden image options
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: 'echo "\[INFO\] Helm chart overridden CATALINA_OPTS value for '
+      # Verify final export of combined CATALINA_OPTS
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: 'export CATALINA_OPTS="\$\{combined_opts# \}"'

--- a/geoserver/latest/tests/statefulset_test.yaml
+++ b/geoserver/latest/tests/statefulset_test.yaml
@@ -104,3 +104,43 @@ tests:
           content:
             name: GEOWEBCACHE_CACHE_DIR
             value: /var/geoserver/gwc_cache_dir
+
+  - it: should pass HELM_CATALINA_OPTS env variable and deduplicate options in container command
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HELM_CATALINA_OPTS
+            value: "-Xms$(JAVA_XMS) -Xmx$(JAVA_XMX) -Djava.awt.headless=true -server -Dfile.encoding=UTF8 \
+              \ -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC \
+              \ -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true \
+              \ -Dorg.geotools.coverage.jaiext.enabled=\"$(JAI_EXT_ENABLED)\" -DGEOSERVER_LOG_LOCATION=\"$(GEOSERVER_LOG_LOCATION)\" -DGEOWEBCACHE_CONFIG_DIR=\"$(GEOWEBCACHE_CONFIG_DIR)\" \
+              \ -DGEOWEBCACHE_CACHE_DIR=$(GEOWEBCACHE_CACHE_DIR) -DNETCDF_DATA_DIR=$(NETCDF_DATA_DIR) -DGRIB_CACHE_DIR=$(GRIB_CACHE_DIR) -DGEOSERVER_CSRF_DISABLED=\"$(GEOSERVER_CSRF_DISABLED)\" \
+              \ -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$(GEOSERVER_HEAP_DUMP_DIR)/$(POD_HOSTNAME).hprof -DGEOSERVER_DATA_DIR=\"$(GEOSERVER_DATA_DIR)\" \
+              \ -DGEOSERVER_AUDIT_PATH=\"$(GEOSERVER_AUDIT_PATH)\" -Dpod.hostname=\"$(POD_HOSTNAME)\" \
+              \ -DALLOW_ENV_PARAMETRIZATION=true -DPROXY_BASE_URL='$(PROXY_BASE_URL)' -DPROXY_BASE_URL_HEADERS='$(PROXY_BASE_URL_HEADERS)'"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'for opt in \$\{HELM_CATALINA_OPTS\}; do'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'for opt in \$\{CATALINA_OPTS\}; do'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '-Xms\*\) key="-Xms"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '-Xmx\*\) key="-Xmx"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '-XX:\*\) key="\$\{opt%%=\*\}"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '-D\*\)   key="\$\{opt%%=\*\}"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'echo "\[INFO\] Helm chart overridden CATALINA_OPTS value for '
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'export CATALINA_OPTS="\$\{combined_opts# \}"'


### PR DESCRIPTION
Fixes https://github.com/geosolutions-it/charts/issues/70
Fixes https://github.com/geosolutions-it/support/issues/6395

- Use a dedicated variable HELM_CATALINA_OPTS and deduplicate using this ensuring helm chart values take precedence.
- Add logging to gain visibility on which image related values were overridden by helm chart.

Tested:

<details><summary>[process listing] Before</summary>
<p>

```sh
tomcat        17 287  5.5 11185944 1741356 ?        Sl   10:15   0:28 /opt/java/openjdk/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties -Djava.util.logging.
          manager=org.apache.juli.ClassLoaderLogManager -Xms4G -Xmx4G -Djava.awt.headless=true -server -Dfile.encoding=UTF8 -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -
          XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true -Dorg.geotools.coverage.
          jaiext.enabled=true -DGEOSERVER_LOG_LOCATION=/var/geoserver/logs/geoserver-0.log -DGEOWEBCACHE_CONFIG_DIR=/var/geoserver/datadir/gwc -DGEOWEBCACHE_CACHE_DIR=/var/geoserver/datadir/gwc_cache_dir -
          DNETCDF_DATA_DIR=/var/geoserver/netcdf_data_dir -DGRIB_CACHE_DIR=/var/geoserver/grib_cache_dir -DGEOSERVER_CSRF_DISABLED=true -XX:+HeapDumpOnOutOfMemoryError -
          XX:HeapDumpPath=/var/geoserver/memory_dumps/geoserver-0.hprof -DGEOSERVER_DATA_DIR=/var/geoserver/datadir -DGEOSERVER_AUDIT_PATH=/var/geoserver/audits -Dpod.hostname=geoserver-0 -
          DALLOW_ENV_PARAMETRIZATION=true -DPROXY_BASE_URL=${X-Forwarded-Proto}://${X-Forwarded-Host}/geoserver -DPROXY_BASE_URL_HEADERS=true -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.
          apache.catalina.webresources -Dsun.io.useCanonCaches=false -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xms2G -Xmx4G -Djava.awt.headless=true -server -Dfile.encoding=UTF8 -Djavax.servlet.
          request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Dorg.geotools.coverage.
          jaiext.enabled=true -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true -DGEOSERVER_LOG_LOCATION=/var/geoserver/logs/geoserver.log -DGEOWEBCACHE_CONFIG_DIR=/var/geoserver/datadir/gwc -
          DGEOWEBCACHE_CACHE_DIR=/var/geoserver/gwc_cache_dir -DNETCDF_DATA_DIR=/var/geoserver/netcdf_data_dir -DGRIB_CACHE_DIR=/var/geoserver/grib_cache_dir -Dignore.endorsed.dirs= -classpath
          /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.
          startup.Bootstrap start
```

</p>
</details> 

<details><summary>[process listing] After</summary>
<p>

```sh
  tomcat        17 275  5.2 10919668 1651532 ?        Sl   10:15   0:30 /opt/java/openjdk/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties -Djava.util.logging.
          manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dsun.io.useCanonCaches=false -Dorg.apache.catalina.security.
          SecurityListener.UMASK=0027 -Xms4G -Xmx4G -Djava.awt.headless=true -server -Dfile.encoding=UTF8 -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -
          XX:SoftRefLRUPolicyMSPerMB=36000 -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 -Duser.timezone=UTC -Dorg.geotools.shapefile.datetime=true -Dorg.geotools.coverage.
          jaiext.enabled=true -DGEOSERVER_LOG_LOCATION=/var/geoserver/logs/geoserver-0.log -DGEOWEBCACHE_CONFIG_DIR=/var/geoserver/datadir/gwc -DGEOWEBCACHE_CACHE_DIR=/var/geoserver/datadir/gwc_cache_dir -
          DNETCDF_DATA_DIR=/var/geoserver/netcdf_data_dir -DGRIB_CACHE_DIR=/var/geoserver/grib_cache_dir -DGEOSERVER_CSRF_DISABLED=true -XX:+HeapDumpOnOutOfMemoryError -
          XX:HeapDumpPath=/var/geoserver/memory_dumps/geoserver-0.hprof -DGEOSERVER_DATA_DIR=/var/geoserver/datadir -DGEOSERVER_AUDIT_PATH=/var/geoserver/audits -Dpod.hostname=geoserver-0 -
          DALLOW_ENV_PARAMETRIZATION=true -DPROXY_BASE_URL=${X-Forwarded-Proto}://${X-Forwarded-Host}/geoserver -DPROXY_BASE_URL_HEADERS=true -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.
          jar:/usr/local/tomcat/bin/tomcat-juli.jar -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start
```

</p>
</details> 

It should also log what values were overridden by the chart, and that is always helpful IMO:

<details><summary>Logging on startup</summary>
<p>

```
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Xms': image provided '-Xms2G'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Xmx': image provided '-Xmx4G'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Djava.awt.headless': image provided '-Djava.awt.headless=true'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-server': image provided '-server'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Dfile.encoding': image provided '-Dfile.encoding=UTF8'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Djavax.servlet.request.encoding': image provided '-Djavax.servlet.request.encoding=UTF-8'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Djavax.servlet.response.encoding': image provided '-Djavax.servlet.response.encoding=UTF-8'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-XX:SoftRefLRUPolicyMSPerMB': image provided '-XX:SoftRefLRUPolicyMSPerMB=36000'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-XX:+UseG1GC': image provided '-XX:+UseG1GC'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-XX:MaxGCPauseMillis': image provided '-XX:MaxGCPauseMillis=200'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-XX:ParallelGCThreads': image provided '-XX:ParallelGCThreads=20'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-XX:ConcGCThreads': image provided '-XX:ConcGCThreads=5'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Dorg.geotools.coverage.jaiext.enabled': image provided '-Dorg.geotools.coverage.jaiext.enabled=true'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Duser.timezone': image provided '-Duser.timezone=UTC'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-Dorg.geotools.shapefile.datetime': image provided '-Dorg.geotools.shapefile.datetime=true'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-DGEOSERVER_LOG_LOCATION': image provided '-DGEOSERVER_LOG_LOCATION=/var/geoserver/logs/geoserver.log'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-DGEOWEBCACHE_CONFIG_DIR': image provided '-DGEOWEBCACHE_CONFIG_DIR=/var/geoserver/datadir/gwc'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-DGEOWEBCACHE_CACHE_DIR': image provided '-DGEOWEBCACHE_CACHE_DIR=/var/geoserver/gwc_cache_dir'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-DNETCDF_DATA_DIR': image provided '-DNETCDF_DATA_DIR=/var/geoserver/netcdf_data_dir'
      [INFO] Helm chart overridden CATALINA_OPTS value for '-DGRIB_CACHE_DIR': image provided '-DGRIB_CACHE_DIR=/var/geoserver/grib_cache_dir'
```

</p>
</details> 