### PR TITLE
feat(geoserver): add Tomcat maxHttpHeaderSize support to GeoServer chart

### DIFF
--- a/geoserver/latest/Chart.yaml
+++ b/geoserver/latest/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/geoserver/latest/README.md
+++ b/geoserver/latest/README.md
@@ -73,9 +73,16 @@ kubectl port-forward geoserver-0 8080:8080
 - Possibility to enable or disable [CSRF (Cross-Site Request Forgery)](https://docs.geoserver.org/stable/en/user/security/webadmin/csrf.html)
 - configure tomcat's `Xmx`  maximum Java heap size
 - configure tomcat's `Xms` initial Java heap size.
+- configure Tomcat HTTP Connector maximum header size.
 - Possibility to populate the `environment.properties` file with custom env vars, to have them available in the GeoServer config
 
 ```yml
+tomcat:
+  httpConnector:
+    # Maximum size in bytes for HTTP request and response headers.
+    # Leave empty to use Tomcat's default.
+    maxHttpHeaderSize: 65536
+
 geoserver:
   # space separated list of plugin URLs (see also this possibility below to format such string)
   # plugins: "https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.4/extensions/geoserver-2.20.4-monitor-plugin.zip \

--- a/geoserver/latest/templates/configmap.yml
+++ b/geoserver/latest/templates/configmap.yml
@@ -74,10 +74,13 @@ data:
              APR (HTTP/AJP) Connector: /docs/apr.html
              Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
         -->
+        {{- $tomcat := get .Values "tomcat" | default dict }}
+        {{- $httpConnector := get $tomcat "httpConnector" | default dict }}
+        {{- $maxHttpHeaderSize := get $httpConnector "maxHttpHeaderSize" | default "" }}
         <Connector port="8080" protocol="HTTP/1.1"
                    connectionTimeout="20000"
-                   {{- if .Values.tomcat.httpConnector.maxHttpHeaderSize }}
-                   maxHttpHeaderSize="{{ .Values.tomcat.httpConnector.maxHttpHeaderSize }}"
+                   {{- if $maxHttpHeaderSize }}
+                   maxHttpHeaderSize="{{ $maxHttpHeaderSize }}"
                    {{- end }}
                    redirectPort="8443" />
         <!-- A "Connector" using the shared thread pool-->

--- a/geoserver/latest/templates/configmap.yml
+++ b/geoserver/latest/templates/configmap.yml
@@ -76,6 +76,9 @@ data:
         -->
         <Connector port="8080" protocol="HTTP/1.1"
                    connectionTimeout="20000"
+                   {{- if .Values.tomcat.httpConnector.maxHttpHeaderSize }}
+                   maxHttpHeaderSize="{{ .Values.tomcat.httpConnector.maxHttpHeaderSize }}"
+                   {{- end }}
                    redirectPort="8443" />
         <!-- A "Connector" using the shared thread pool-->
         <!--

--- a/geoserver/latest/templates/statefulset.yaml
+++ b/geoserver/latest/templates/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -127,9 +127,9 @@ postgis:
     database: geoserver
     user: geoserver
 
-# tomcat:
-#   httpConnector:
-#     maxHttpHeaderSize: "10000"
+tomcat:
+  httpConnector:
+    maxHttpHeaderSize: "10000"
 
 geoserver:
   # space separated list of plugin URLs (see also this possibility below to format such string)

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -126,6 +126,11 @@ postgis:
   env:
     database: geoserver
     user: geoserver
+
+tomcat:
+  httpConnector:
+    maxHttpHeaderSize: ""
+
 geoserver:
   # space separated list of plugin URLs (see also this possibility below to format such string)
   # plugins: "https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.4/extensions/geoserver-2.20.4-monitor-plugin.zip \
@@ -151,3 +156,5 @@ geoserver:
   geoserver_cors_allowed_origins: "*"
   geoserver_cors_allowed_headers: "*"
   geoserver_cors_allow_credentials: "false"
+
+  env_properties: ""

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -127,9 +127,9 @@ postgis:
     database: geoserver
     user: geoserver
 
-tomcat:
-  httpConnector:
-    maxHttpHeaderSize: ""
+# tomcat:
+#   httpConnector:
+#     maxHttpHeaderSize: "10000"
 
 geoserver:
   # space separated list of plugin URLs (see also this possibility below to format such string)
@@ -156,5 +156,3 @@ geoserver:
   geoserver_cors_allowed_origins: "*"
   geoserver_cors_allowed_headers: "*"
   geoserver_cors_allow_credentials: "false"
-
-  env_properties: ""


### PR DESCRIPTION
This PR adds support for configuring Tomcat `maxHttpHeaderSize` through the GeoServer Helm chart and also adds a ConfigMap checksum annotation so changes to the generated `server.xml` trigger a StatefulSet rollout during `helm upgrade`.