### PR TITLE
feat(geoserver): add geoserver maxHttpHeaderSize

### DIFF
--- a/geoserver/latest/Chart.yaml
+++ b/geoserver/latest/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/geoserver/latest/README.md
+++ b/geoserver/latest/README.md
@@ -160,7 +160,7 @@ Example:
 tomcat:
   httpConnector:
     # Maximum size in bytes for HTTP request and response headers.
-    # Leave empty to use Tomcat's default.
+    # Leave empty to omit the attribute from server.xml.
     maxHttpHeaderSize: 65536
 
 geoserver:
@@ -207,7 +207,7 @@ geoserver:
 #### Description:
 - `chown_datadir`: toggle running `chown` to the `tomcat` UID/GID on the GeoServer data\_dir.  
   Disabling this might be desired when particular storage drivers requires to not change the ownership.
-- `tomcat.httpConnector.maxHttpHeaderSize`: optional Tomcat HTTP Connector `maxHttpHeaderSize` value in bytes. This sets Tomcat's default maximum size for both request and response headers. For example, use `65536` for 64 KiB.
+- `tomcat.httpConnector.maxHttpHeaderSize`: optional Tomcat HTTP Connector `maxHttpHeaderSize` value in bytes. When set, this value is applied to both request and response header size limits unless the more specific Tomcat connector attributes are configured separately. For example, use `65536` for 64 KiB.
 - `geoserver_extra_opts`: JVM options that will be appended to the default ones.
 - `env_properties`: list of entries; set `external: true` to read from an existing Secret named in `value` (secret key defaults to the property `name`), or leave `external` false/omitted to use the cleartext `value`. Rendered into `/usr/local/tomcat/conf/environment.properties`.
 

--- a/geoserver/latest/README.md
+++ b/geoserver/latest/README.md
@@ -152,10 +152,17 @@ In this configuration:
 - Possibility to enable or disable [CSRF (Cross-Site Request Forgery)](https://docs.geoserver.org/stable/en/user/security/webadmin/csrf.html)
 - configure tomcat's `Xmx`  maximum Java heap size
 - configure tomcat's `Xms` initial Java heap size.
+- configure Tomcat HTTP Connector maximum header size.
 - Possibility to populate the `environment.properties` file with custom env vars, to have them available in the GeoServer config
 
 Example:
 ```yml
+tomcat:
+  httpConnector:
+    # Maximum size in bytes for HTTP request and response headers.
+    # Leave empty to use Tomcat's default.
+    maxHttpHeaderSize: 65536
+
 geoserver:
   chown_datadir: true
 
@@ -200,6 +207,7 @@ geoserver:
 #### Description:
 - `chown_datadir`: toggle running `chown` to the `tomcat` UID/GID on the GeoServer data\_dir.  
   Disabling this might be desired when particular storage drivers requires to not change the ownership.
+- `tomcat.httpConnector.maxHttpHeaderSize`: optional Tomcat HTTP Connector `maxHttpHeaderSize` value in bytes. This sets Tomcat's default maximum size for both request and response headers. For example, use `65536` for 64 KiB.
 - `geoserver_extra_opts`: JVM options that will be appended to the default ones.
 - `env_properties`: list of entries; set `external: true` to read from an existing Secret named in `value` (secret key defaults to the property `name`), or leave `external` false/omitted to use the cleartext `value`. Rendered into `/usr/local/tomcat/conf/environment.properties`.
 

--- a/geoserver/latest/templates/configmap.yml
+++ b/geoserver/latest/templates/configmap.yml
@@ -75,8 +75,14 @@ data:
              APR (HTTP/AJP) Connector: /docs/apr.html
              Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
         -->
+        {{- $tomcat := get .Values "tomcat" | default dict }}
+        {{- $httpConnector := get $tomcat "httpConnector" | default dict }}
+        {{- $maxHttpHeaderSize := get $httpConnector "maxHttpHeaderSize" | default "" }}
         <Connector port="8080" protocol="HTTP/1.1"
                    connectionTimeout="20000"
+                   {{- if $maxHttpHeaderSize }}
+                   maxHttpHeaderSize="{{ $maxHttpHeaderSize }}"
+                   {{- end }}
                    redirectPort="8443" />
         <!-- A "Connector" using the shared thread pool-->
         <!--

--- a/geoserver/latest/tests/statefulset_test.yaml
+++ b/geoserver/latest/tests/statefulset_test.yaml
@@ -32,6 +32,22 @@ tests:
           path: metadata.labels["app.kubernetes.io/name"]
           value: geoserver
 
+  - it: should not set Tomcat max HTTP header size by default
+    template: configmap.yml
+    asserts:
+      - notMatchRegex:
+          path: data["server.xml"]
+          pattern: 'maxHttpHeaderSize='
+
+  - it: should set Tomcat max HTTP header size
+    template: configmap.yml
+    set:
+      tomcat.httpConnector.maxHttpHeaderSize: 65536
+    asserts:
+      - matchRegex:
+          path: data["server.xml"]
+          pattern: 'maxHttpHeaderSize="65536"'
+
   - it: should keep cache data dir under geoserver data dir by default
     template: statefulset.yaml
     asserts:

--- a/geoserver/latest/values.yaml
+++ b/geoserver/latest/values.yaml
@@ -153,6 +153,11 @@ postgis:
   env:
     database: geoserver
     user: geoserver
+
+tomcat:
+  httpConnector:
+    maxHttpHeaderSize: ""
+
 geoserver:
   chown_datadir: false
 


### PR DESCRIPTION
This PR adds support for configuring Tomcat `maxHttpHeaderSize` through the GeoServer Helm chart